### PR TITLE
Fix commit message GHA syntax and changelog printf

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -101,7 +101,7 @@ jobs:
           FIRST_HEADING=$(grep -n "^## " "$CHANGELOG" | head -1 | cut -d: -f1)
           if [ -n "$FIRST_HEADING" ]; then
             head -n $((FIRST_HEADING - 1)) "$CHANGELOG" > changelog.tmp
-            echo -e "$ENTRY" >> changelog.tmp
+            printf '%b\n' "$ENTRY" >> changelog.tmp
             tail -n +$FIRST_HEADING "$CHANGELOG" >> changelog.tmp
             mv changelog.tmp "$CHANGELOG"
           fi
@@ -122,7 +122,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
-          git commit -m "docs: regenerate ${steps.result.outputs.pages_written} pages from PAI ${inputs.pai_sha:0:7}
+          SHORT_SHA=$(echo "${{ inputs.pai_sha }}" | cut -c1-7)
+          git commit -m "docs: regenerate ${{ steps.result.outputs.pages_written }} pages from PAI ${SHORT_SHA}
 
           Pages updated: ${{ steps.result.outputs.page_list }}
           PAI SHA: ${{ inputs.pai_sha }}"


### PR DESCRIPTION
## Summary

- **Fixed commit message**: Used bash `${}` instead of GHA `${{ }}` for `pages_written` and `pai_sha` — these expanded to empty strings, producing broken commit messages like `"docs: regenerate  pages from PAI "`
- **Fixed SHA truncation**: `${inputs.pai_sha:0:7}` (bash substring on non-existent var) replaced with `$(echo "${{ inputs.pai_sha }}" | cut -c1-7)`
- **Hardened changelog entry**: Switched `echo -e` to `printf '%b'` for more robust escape sequence handling

## Verified working (no changes needed)

- sed pattern for footer `Site vX.Y.Z` replacement ✓
- Changelog `## ` heading detection at line 13 ✓
- `NEW_VERSION` env var propagation between steps ✓
- `.regeneration-result.json` field names match jq queries ✓

## Test plan

- [ ] Verify no remaining `${lowercase...}` GHA expression mistakes (`grep` confirmed clean)
- [ ] Verify build passes (`npm run build` succeeded)
- [ ] After merge + #24 pipeline fix, trigger watcher to validate full end-to-end

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)